### PR TITLE
Support for .xcloc files

### DIFF
--- a/Xliffie/AppDelegate.m
+++ b/Xliffie/AppDelegate.m
@@ -157,16 +157,16 @@
 }
 
 - (BOOL)isFilePathXcloc:(NSString*)filePath:(NSArray*)files {
-    BOOL hasLocalizedContents = false;
-    BOOL hasContentsJson = false;
+    BOOL hasLocalizedContents = NO;
+    BOOL hasContentsJson = NO;
     
     for (NSString *filename in files) {
         if ([filename isEqualToString:@"Localized Contents"]) {
-            hasLocalizedContents = true;
+            hasLocalizedContents = YES;
         }
         
         if ([filename isEqualToString:@"contents.json"]) {
-            hasContentsJson = true;
+            hasContentsJson = YES;
         }
     }
     

--- a/Xliffie/AppDelegate.m
+++ b/Xliffie/AppDelegate.m
@@ -50,6 +50,13 @@
                 }
             } else {
                 NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:thisItem error:nil];
+                BOOL isXcloc = [self isFilePathXcloc:thisItem:files];
+                
+                if (isXcloc) {
+                    thisItem = [NSString stringWithFormat:@"%@/%@", thisItem, @"Localized Contents"];
+                    files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:thisItem error:nil];
+                }
+
                 for (NSString *filename in files) {
                     if ([self isFilePathXliff:filename]) {
                         [inputs addObject:[thisItem stringByAppendingPathComponent:filename]];
@@ -144,6 +151,28 @@
     if ([[filePath pathExtension] isEqualToString:@"xliff"] ||
         [[filePath pathExtension] isEqualToString:@"xlif"] ||
         [[filePath pathExtension] isEqualToString:@"xlf"]) {
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)isFilePathXcloc:(NSString*)filePath:(NSArray*)files {
+    BOOL hasLocalizedContents = false;
+    BOOL hasContentsJson = false;
+    
+    for (NSString *filename in files) {
+        if ([filename isEqualToString:@"Localized Contents"]) {
+            hasLocalizedContents = true;
+        }
+        
+        if ([filename isEqualToString:@"contents.json"]) {
+            hasContentsJson = true;
+        }
+    }
+    
+    if ([[filePath pathExtension] isEqualToString:@"xcloc"] &&
+        hasContentsJson &&
+        hasLocalizedContents) {
         return YES;
     }
     return NO;

--- a/Xliffie/AppDelegate.m
+++ b/Xliffie/AppDelegate.m
@@ -156,10 +156,12 @@
     return NO;
 }
 
-- (BOOL)isFilePathXcloc:(NSString*)filePath:(NSArray*)files {
+- (BOOL)isFilePathXcloc: (NSString*)filePath : (NSArray*)files {
     BOOL hasLocalizedContents = NO;
     BOOL hasContentsJson = NO;
-    
+    BOOL hasSourceContents = NO;
+    BOOL hasNotes = NO;
+
     for (NSString *filename in files) {
         if ([filename isEqualToString:@"Localized Contents"]) {
             hasLocalizedContents = YES;
@@ -168,13 +170,24 @@
         if ([filename isEqualToString:@"contents.json"]) {
             hasContentsJson = YES;
         }
+
+        if ([filename isEqualToString:@"Source Contents"]) {
+            hasSourceContents = YES;
+        }
+
+        if ([filename isEqualToString:@"Notes"]) {
+            hasNotes = YES;
+        }
     }
-    
+
     if ([[filePath pathExtension] isEqualToString:@"xcloc"] &&
         hasContentsJson &&
-        hasLocalizedContents) {
+        hasLocalizedContents &&
+        hasSourceContents &&
+        hasNotes) {
         return YES;
     }
+
     return NO;
 }
 

--- a/Xliffie/AppDelegate.m
+++ b/Xliffie/AppDelegate.m
@@ -51,7 +51,7 @@
             } else {
                 NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:thisItem error:nil];
                 BOOL isXcloc = [self isFilePathXcloc:thisItem:files];
-                
+
                 if (isXcloc) {
                     thisItem = [NSString stringWithFormat:@"%@/%@", thisItem, @"Localized Contents"];
                     files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:thisItem error:nil];

--- a/Xliffie/Document.m
+++ b/Xliffie/Document.m
@@ -104,6 +104,41 @@
     return YES;
 }
 
+- (BOOL)readFromFileWrapper:(NSFileWrapper *)fileWrapper ofType:(NSString *)typeName error:(NSError * _Nullable *)outError {
+//    Case for handling drag and drop
+    if ([[[fileWrapper filename] pathExtension] isEqualToString:@"xliff"] ||
+        [[[fileWrapper filename] pathExtension] isEqualToString:@"xlif"] ||
+        [[[fileWrapper filename] pathExtension] isEqualToString:@"xlf"]) {
+        NSData *xmlData = [fileWrapper regularFileContents];
+
+        [self readFromData:xmlData ofType:typeName error:outError];
+        return YES;
+    }
+
+//    Case for handling open from dialog
+    if ([fileWrapper isDirectory]) {
+        NSDictionary *fileWrappers = [fileWrapper fileWrappers];
+
+        for (id key in fileWrappers) {
+            NSFileWrapper* fw = [fileWrappers objectForKey:key];
+            if ([[fw filename] isEqualToString:@"Localized Contents"]) {
+                return [self readFromFileWrapper:fw ofType:typeName error:outError];
+            }
+
+            if ([[[fw filename] pathExtension] isEqualToString:@"xliff"] ||
+                [[[fw filename] pathExtension] isEqualToString:@"xlif"] ||
+                [[[fw filename] pathExtension] isEqualToString:@"xlf"]) {
+                NSData *xmlData = [fw regularFileContents];
+
+                [self readFromData:xmlData ofType:typeName error:outError];
+                return YES;
+            }
+        }
+    }
+
+    return NO;
+}
+
 # pragma mark filter
 
 - (Document*)filteredDocumentWithSearchFilter:(NSString*)filter {

--- a/Xliffie/Info.plist
+++ b/Xliffie/Info.plist
@@ -7,6 +7,20 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
+			<key>NSDocumentClass</key>
+			<string>Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<true/>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>xcloc</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Xcloc file</string>
+		</dict>
+		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>xlif</string>


### PR DESCRIPTION
Attempts to support #5 

- [x]  Support opening the .xcloc folders, the behaviour should be the same as opening the inner .xliff file.
  - [x] Double click on the folder should open Xliffie
- [x]  Associate multiple .xcloc folders to the same window, just like how xliff files are associated
- [ ]  The app should still be able to support the old folder structure

